### PR TITLE
Enable progress indicator for page load with WebviewScaffold

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .DS_Store
 .atom/
 .idea
+.vscode
 .packages
 .pub/
 build/

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 # flutter_webview_plugin
 
-Plugin that allow Flutter to communicate with a native WebView.
+Plugin that allows Flutter to communicate with a native WebView.
 
 ***Warning:***
 The webview is not integrated in the widget tree, it is a native view on top of the flutter view.

--- a/README.md
+++ b/README.md
@@ -30,6 +30,38 @@ new MaterialApp(
     );
 ```
 
+Optional parameters `hidden` and `initialChild` are available so that you can show something else while waiting for the page to load.
+If you set `hidden` to true it will show a default CircularProgressIndicator. If you additionally specify a Widget for initialChild
+you can have it display whatever you like till page-load.
+
+e.g. The following will show a read screen with the text 'waiting.....'.
+```dart
+return new MaterialApp(
+  title: 'Flutter WebView Demo',
+  theme: new ThemeData(
+    primarySwatch: Colors.blue,
+  ),
+  routes: {
+    '/': (_) => const MyHomePage(title: 'Flutter WebView Demo'),
+    '/widget': (_) => new WebviewScaffold(
+          url: selectedUrl,
+          appBar: new AppBar(
+            title: const Text('Widget webview'),
+          ),
+          withZoom: true,
+          withLocalStorage: true,
+          hidden: true,
+          initialChild: Container(
+            color: Colors.redAccent,
+            child: const Center(
+              child: Text('Waiting.....'),
+            ),
+          ),
+        )
+  },
+);
+```
+
 `FlutterWebviewPlugin` provide a singleton instance linked to one unique webview,
 so you can take control of the webview from anywhere in the app
 

--- a/example/ios/Runner.xcodeproj/project.pbxproj
+++ b/example/ios/Runner.xcodeproj/project.pbxproj
@@ -242,7 +242,7 @@
 			);
 			inputPaths = (
 				"${SRCROOT}/Pods/Target Support Files/Pods-Runner/Pods-Runner-frameworks.sh",
-				"${PODS_ROOT}/../../../../../development/flutter/bin/cache/artifacts/engine/ios/Flutter.framework",
+				"${PODS_ROOT}/../../../../../flutter/bin/cache/artifacts/engine/ios/Flutter.framework",
 				"${BUILT_PRODUCTS_DIR}/flutter_webview_plugin/flutter_webview_plugin.framework",
 			);
 			name = "[CP] Embed Pods Frameworks";

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -30,6 +30,13 @@ class MyApp extends StatelessWidget {
               ),
               withZoom: true,
               withLocalStorage: true,
+              hidden: true,
+              initialChild: Container(
+                color: Colors.redAccent,
+                child: const Center(
+                  child: Text('Waiting.....'),
+                ),
+              ),
             )
       },
     );
@@ -121,6 +128,7 @@ class _MyHomePageState extends State<MyHomePage> {
 
     _onStateChanged =
         flutterWebviewPlugin.onStateChanged.listen((WebViewStateChanged state) {
+
       if (mounted) {
         setState(() {
           _history.add('onStateChanged: ${state.type} ${state.url}');

--- a/lib/src/webview_scaffold.dart
+++ b/lib/src/webview_scaffold.dart
@@ -42,7 +42,7 @@ class WebviewScaffold extends StatefulWidget {
       this.withLocalStorage,
       this.withLocalUrl,
       this.scrollBar,
-      this.hidden : false,
+      this.hidden = false,
       this.initialChild})
       : super(key: key);
 
@@ -61,18 +61,22 @@ class _WebviewScaffoldState extends State<WebviewScaffold> {
     super.initState();
     webviewReference.close();
 
-    _onStateChanged = webviewReference.onStateChanged.listen((WebViewStateChanged state) {
-      if (state.type == WebViewState.finishLoad) {
-        webviewReference.show();
-      }
-    });
+    if (widget.hidden) {
+      _onStateChanged = webviewReference.onStateChanged.listen((WebViewStateChanged state) {
+        if (state.type == WebViewState.finishLoad) {
+          webviewReference.show();
+        }
+      });
+    }
   }
 
   @override
   void dispose() {
     super.dispose();
     webviewReference.close();
-    _onStateChanged.cancel();
+    if (widget.hidden) {
+      _onStateChanged.cancel();
+    }
     webviewReference.dispose();
   }
 
@@ -116,20 +120,17 @@ class _WebviewScaffoldState extends State<WebviewScaffold> {
 
     final mediaQuery = MediaQuery.of(context);
     final topPadding = widget.primary ? mediaQuery.padding.top : 0.0;
-    final top =
-        fullscreen ? 0.0 : widget.appBar.preferredSize.height + topPadding;
+    final top = fullscreen ? 0.0 : widget.appBar.preferredSize.height + topPadding;
 
     var height = mediaQuery.size.height - top;
 
     if (widget.bottomNavigationBar != null) {
       height -= 56.0 +
-          mediaQuery.padding
-              .bottom; // todo(lejard_h) find a way to determine bottomNavigationBar programmatically
+          mediaQuery.padding.bottom; // todo(lejard_h) find a way to determine bottomNavigationBar programmatically
     }
 
     if (widget.persistentFooterButtons != null) {
-      height -=
-          53.0; // todo(lejard_h) find a way to determine persistentFooterButtons programmatically
+      height -= 53.0; // todo(lejard_h) find a way to determine persistentFooterButtons programmatically
       if (widget.bottomNavigationBar == null) {
         height -= mediaQuery.padding.bottom;
       }


### PR DESCRIPTION
With regards to issue https://github.com/dart-flitter/flutter_webview_plugin/issues/159 which was a request to enable a page load "waiting" indicator of some sort. I've had a quick crack at it myself here.

Added two optional parameters to the WebviewScaffold widget: `hidden` and `initialChild`.
By setting `hidden` to true the underling Scaffold widget is shown (defaulting to a CircularProgressIndicator as the body). Then we track the state change so that when the page is loaded `show()` is called on the webview.
If the `initialChild` parameter is also set to a Widget - then it is shown instead of the default CircularProgressIndicator.