### PR TITLE
Upgrade compile sdk version to 27

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -21,7 +21,7 @@ allprojects {
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 25
+    compileSdkVersion 27
     buildToolsVersion '27.0.3'
 
     defaultConfig {


### PR DESCRIPTION
Upgrade compile sdk version so that developer and CI don't need to download extra android sdk platform 25 to compile this package. The plugin works well by using sdk platform 27.