### PR TITLE
Do not call onReceiveValue on null reference

### DIFF
--- a/android/src/main/java/com/flutter_webview_plugin/WebviewManager.java
+++ b/android/src/main/java/com/flutter_webview_plugin/WebviewManager.java
@@ -52,7 +52,8 @@ class WebviewManager {
                         handled = true;
                     }
                 }
-                mUploadMessageArray.onReceiveValue(results);
+                if (mUploadMessageArray != null)
+                    mUploadMessageArray.onReceiveValue(results);
                 mUploadMessageArray = null;
             }else {
                 if (requestCode == FILECHOOSER_RESULTCODE) {

--- a/android/src/main/java/com/flutter_webview_plugin/WebviewManager.java
+++ b/android/src/main/java/com/flutter_webview_plugin/WebviewManager.java
@@ -52,15 +52,18 @@ class WebviewManager {
                         handled = true;
                     }
                 }
-                if (mUploadMessageArray != null)
+                if (mUploadMessageArray != null){
                     mUploadMessageArray.onReceiveValue(results);
+                }
                 mUploadMessageArray = null;
             }else {
                 if (requestCode == FILECHOOSER_RESULTCODE) {
                     if (null != mUploadMessage) {
                         Uri result = intent == null || resultCode != RESULT_OK ? null
                                 : intent.getData();
-                        mUploadMessage.onReceiveValue(result);
+                        if (mUploadMessageArray != null){
+                            mUploadMessageArray.onReceiveValue(results);
+                        }
                         mUploadMessage = null;
                     }
                     handled = true;


### PR DESCRIPTION
In my project I'm using an Image picker. On Android after the image picker is displayed and the user has picked an image, the Flutter Webview Plugin crashes with null pointer exception on WebviewManager.java line 55. To avoid this please consider my pull request.