### PR TITLE
Fix clear cache and cookies on iOS.

### DIFF
--- a/android/src/main/java/com/flutter_webview_plugin/FlutterWebviewPlugin.java
+++ b/android/src/main/java/com/flutter_webview_plugin/FlutterWebviewPlugin.java
@@ -61,6 +61,9 @@ public class FlutterWebviewPlugin implements MethodCallHandler, PluginRegistry.A
             case "back":
                 back(call, result);
                 break;
+            case "canGoBack":
+                canGoBack(call, result);
+                break;
             case "forward":
                 forward(call, result);
                 break;
@@ -171,6 +174,13 @@ public class FlutterWebviewPlugin implements MethodCallHandler, PluginRegistry.A
     private void back(MethodCall call, MethodChannel.Result result) {
         if (webViewManager != null) {
             webViewManager.back(call, result);
+        }
+        result.success(null);
+    }
+
+    private void canGoBack(MethodCall call, MethodChannel.Result result) {
+        if (webViewManager != null) {
+            result.success(webViewManager.canGoBack());
         }
         result.success(null);
     }

--- a/ios/Classes/FlutterWebviewPlugin.m
+++ b/ios/Classes/FlutterWebviewPlugin.m
@@ -64,6 +64,8 @@ static NSString *const CHANNEL_NAME = @"flutter_webview_plugin";
     } else if ([@"back" isEqualToString:call.method]) {
         [self back];
         result(nil);
+    } else if ([@"canGoBack" isEqualToString:call.method]) {
+        result([NSNumber numberWithBool:self.webview.canGoBack]);
     } else if ([@"forward" isEqualToString:call.method]) {
         [self forward];
         result(nil);

--- a/ios/Classes/FlutterWebviewPlugin.m
+++ b/ios/Classes/FlutterWebviewPlugin.m
@@ -102,8 +102,14 @@ static NSString *const CHANNEL_NAME = @"flutter_webview_plugin";
     }
 
     if (clearCookies != (id)[NSNull null] && [clearCookies boolValue]) {
-        [[NSURLSession sharedSession] resetWithCompletionHandler:^{
-        }];
+        if (@available(iOS 9.0, *)) {
+            NSSet *dataTypes = [NSSet setWithArray:@[WKWebsiteDataTypeCookies]];
+            [[WKWebsiteDataStore defaultDataStore] removeDataOfTypes:dataTypes modifiedSince:[NSDate dateWithTimeIntervalSince1970:0] completionHandler:^(){
+            }];
+        } else {
+            [[NSURLSession sharedSession] resetWithCompletionHandler:^{
+            }];
+        }
     }
 
     if (userAgent != (id)[NSNull null]) {

--- a/ios/Classes/FlutterWebviewPlugin.m
+++ b/ios/Classes/FlutterWebviewPlugin.m
@@ -88,7 +88,17 @@ static NSString *const CHANNEL_NAME = @"flutter_webview_plugin";
     _invalidUrlRegex = call.arguments[@"invalidUrlRegex"];
 
     if (clearCache != (id)[NSNull null] && [clearCache boolValue]) {
-        [[NSURLCache sharedURLCache] removeAllCachedResponses];
+        if (@available(iOS 11.3, *)) {
+            NSSet *dataTypes = [NSSet setWithArray:@[WKWebsiteDataTypeDiskCache, WKWebsiteDataTypeMemoryCache, WKWebsiteDataTypeFetchCache]];
+            [[WKWebsiteDataStore defaultDataStore] removeDataOfTypes:dataTypes modifiedSince:[NSDate dateWithTimeIntervalSince1970:0] completionHandler:^(){
+            }];
+        } else if (@available(iOS 9.0, *)) {
+            NSSet *dataTypes = [NSSet setWithArray:@[WKWebsiteDataTypeDiskCache, WKWebsiteDataTypeMemoryCache]];
+            [[WKWebsiteDataStore defaultDataStore] removeDataOfTypes:dataTypes modifiedSince:[NSDate dateWithTimeIntervalSince1970:0] completionHandler:^(){
+            }];
+        } else {
+            [[NSURLCache sharedURLCache] removeAllCachedResponses];
+        }
     }
 
     if (clearCookies != (id)[NSNull null] && [clearCookies boolValue]) {

--- a/lib/src/base.dart
+++ b/lib/src/base.dart
@@ -182,6 +182,8 @@ class FlutterWebviewPlugin {
   /// Navigates back on the Webview.
   Future<Null> goBack() async => await _channel.invokeMethod('back');
 
+  Future<bool> canGoBack() async => await _channel.invokeMethod('canGoBack');
+
   /// Navigates forward on the Webview.
   Future<Null> goForward() async => await _channel.invokeMethod('forward');
 


### PR DESCRIPTION
In my project, `clearCookies` and `clearCache` are not working on iOS9 or later,
because storage destination is different depending on OS.
So, add removing them on each OS.
