### PR TITLE
adding minSdkVersion

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -25,6 +25,7 @@ android {
 
     defaultConfig {
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
+        minSdkVersion 16
     }
     lintOptions {
         disable 'InvalidPackage'


### PR DESCRIPTION
When targetSdkVersion or minSdkVersion is not set or < 4, gradle adds additional scary permissions such as WRITE_EXTERNAL_STORAGE and READ_PHONE_STATE

Setting a higher sdkVersion prevents this.