### PR TITLE
fix exception when intent is null

### DIFF
--- a/android/src/main/java/com/flutter_webview_plugin/WebviewManager.java
+++ b/android/src/main/java/com/flutter_webview_plugin/WebviewManager.java
@@ -42,7 +42,7 @@ class WebviewManager {
             if(Build.VERSION.SDK_INT >= 21){
                 if(requestCode == FILECHOOSER_RESULTCODE){
                     Uri[] results = null;
-                    if(resultCode == Activity.RESULT_OK){
+                    if(resultCode == Activity.RESULT_OK && intent != null){
                         String dataString = intent.getDataString();
                         if(dataString != null){
                             results = new Uri[]{ Uri.parse(dataString) };


### PR DESCRIPTION
`E/AndroidRuntime(21545): java.lang.RuntimeException: Failure delivering result ResultInfo{who=null, request=1, result=-1, data=null} to activity {com.example/com.example.MainActivity}: java.lang.NullPointerException: Attempt to invoke virtual method 'java.lang.String android.content.Intent.getDataString()' on a null object reference
E/AndroidRuntime(21545): 	at android.app.ActivityThread.deliverResults(ActivityThread.java:4360)
E/AndroidRuntime(21545): 	at android.app.ActivityThread.handleSendResult(ActivityThread.java:4402)
E/AndroidRuntime(21545): 	at android.app.servertransaction.ActivityResultItem.execute(ActivityResultItem.java:49)
E/AndroidRuntime(21545): 	at android.app.servertransaction.TransactionExecutor.executeCallbacks(TransactionExecutor.java:108)
E/AndroidRuntime(21545): 	at android.app.servertransaction.TransactionExecutor.execute(TransactionExecutor.java:68)
E/AndroidRuntime(21545): 	at android.app.ActivityThread$H.handleMessage(ActivityThread.java:1808)
E/AndroidRuntime(21545): 	at android.os.Handler.dispatchMessage(Handler.java:106)
E/AndroidRuntime(21545): 	at android.os.Looper.loop(Looper.java:193)
E/AndroidRuntime(21545): 	at android.app.ActivityThread.main(ActivityThread.java:6669)
E/AndroidRuntime(21545): 	at java.lang.reflect.Method.invoke(Native Method)
E/AndroidRuntime(21545): 	at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:493)
E/AndroidRuntime(21545): 	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:858)
E/AndroidRuntime(21545): Caused by: java.lang.NullPointerException: Attempt to invoke virtual method 'java.lang.String android.content.Intent.getDataString()' on a null object reference
E/AndroidRuntime(21545): 	at com.flutter_webview_plugin.WebviewManager$ResultHandler.handleResult(WebviewManager.java:46)
E/AndroidRuntime(21545): 	at com.flutter_webview_plugin.FlutterWebviewPlugin.onActivityResult(FlutterWebviewPlugin.java:241)
E/AndroidRuntime(21545): 	at io.flutter.app.FlutterPluginRegistry.onActivityResult(FlutterPluginRegistry.java:210)
E/AndroidRuntime(21545): 	at io.flutter.app.FlutterActivityDelegate.onActivityResult(FlutterActivityDelegate.java:139)
E/AndroidRuntime(21545): 	at io.flutter.app.FlutterActivity.onActivityResult(FlutterActivity.java:138)
E/AndroidRuntime(21545): 	at com.example.MainActivity.onActivityResult(MainActivity.kt:77)
E/AndroidRuntime(21545): 	at android.app.Activity.dispatchActivityResult(Activity.java:7454)
E/AndroidRuntime(21545): 	at android.app.ActivityThread.deliverResults(ActivityThread.java:4353)
E/AndroidRuntime(21545): 	... 11 more
`