### PR TITLE
Pass hidden state when opening WebViewScaffold

### DIFF
--- a/lib/src/webview_scaffold.dart
+++ b/lib/src/webview_scaffold.dart
@@ -104,6 +104,7 @@ class _WebviewScaffoldState extends State<WebviewScaffold> {
               withJavascript: widget.withJavascript,
               clearCache: widget.clearCache,
               clearCookies: widget.clearCookies,
+              hidden: widget.hidden,
               enableAppScheme: widget.enableAppScheme,
               userAgent: widget.userAgent,
               rect: _rect,


### PR DESCRIPTION
For some reason `WebViewScaffold.hidden` property wasn't passed to `webviewReference.launch` call. Because of that WebView was always visible when shown using scaffold, even when `hidden` was set to `true`