### PR TITLE
Fixing wedget webview callbacks

### DIFF
--- a/lib/src/webview_scaffold.dart
+++ b/lib/src/webview_scaffold.dart
@@ -85,7 +85,7 @@ class _WebviewScaffoldState extends State<WebviewScaffold> {
     if (widget.hidden) {
       _onStateChanged.cancel();
     }
-    webviewReference.dispose();
+    //webviewReference.dispose();
   }
 
   @override


### PR DESCRIPTION
This is a workaround for fixing callbacks not firing after closing wedget webview screen