### PR TITLE
Added `useTransparentBackground` feature for Add2App use cases 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.3.1
+
+- Added `useTransparentBackground` feature for Add2App use cases when the native WebView appears behind the Scaffold
+
 # 0.3.0
 
 - Fixes rect capture issue. Ensures WebView remains in the correct place on screen even when keyboard appears.

--- a/lib/src/webview_scaffold.dart
+++ b/lib/src/webview_scaffold.dart
@@ -30,6 +30,7 @@ class WebviewScaffold extends StatefulWidget {
     this.hidden = false,
     this.initialChild,
     this.allowFileURLs,
+    this.useTransparentBackground,
   }) : super(key: key);
 
   final PreferredSizeWidget appBar;
@@ -52,6 +53,7 @@ class WebviewScaffold extends StatefulWidget {
   final bool hidden;
   final Widget initialChild;
   final bool allowFileURLs;
+  final bool useTransparentBackground;
 
   @override
   _WebviewScaffoldState createState() => _WebviewScaffoldState();
@@ -92,6 +94,8 @@ class _WebviewScaffoldState extends State<WebviewScaffold> {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: widget.appBar,
+      backgroundColor:
+          widget.useTransparentBackground ? Colors.transparent : Theme.of(context).scaffoldBackgroundColor,
       persistentFooterButtons: widget.persistentFooterButtons,
       bottomNavigationBar: widget.bottomNavigationBar,
       body: _WebviewPlaceholder(

--- a/lib/src/webview_scaffold.dart
+++ b/lib/src/webview_scaffold.dart
@@ -30,7 +30,7 @@ class WebviewScaffold extends StatefulWidget {
     this.hidden = false,
     this.initialChild,
     this.allowFileURLs,
-    this.useTransparentBackground,
+    this.useTransparentBackground = false,
   }) : super(key: key);
 
   final PreferredSizeWidget appBar;
@@ -94,8 +94,9 @@ class _WebviewScaffoldState extends State<WebviewScaffold> {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: widget.appBar,
-      backgroundColor:
-          widget.useTransparentBackground ? Colors.transparent : Theme.of(context).scaffoldBackgroundColor,
+      backgroundColor: widget.useTransparentBackground
+          ? Colors.transparent
+          : Theme.of(context).scaffoldBackgroundColor,
       persistentFooterButtons: widget.persistentFooterButtons,
       bottomNavigationBar: widget.bottomNavigationBar,
       body: _WebviewPlaceholder(

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -7,7 +7,7 @@ authors:
 - Simon Lightfoot <simon@devangels.london>
 - Rafal Wachol <gorudonu@gmail.com>
 homepage: https://github.com/dart-flitter/flutter_webview_plugin
-version: 0.3.0+2
+version: 0.3.1
 maintainer: Simon Lightfoot (@slightfoot)
 
 environment:


### PR DESCRIPTION
I'm using Flutter in an Add2App scenario.

I was using the plugin on Android, but the web page did not appear on the screen. While debugging I found out the native WebView is rendered behind the FlutterView. The scaffold used in `webview_scaffold.dart` does not set a background, which will result in the `scaffoldBackgroundColor` value from the `ThemeData` being used. I would prefer to not set a custom background for every scaffold I use and have the theme value be transparent.

If preferred I can change it to allow any custom `backgroundColor` to be set, but in most scenarios it won't even be visible. I think using `backgroundColor` could cause confusion among the users.
This is probably also an issue with how Flutter works in an Add2App scenario. I suspect the FlutterView is always forced on top of other views on Android.
