### PR TITLE
modified comparison to use nil rather than null

### DIFF
--- a/ios/Classes/FlutterWebviewPlugin.m
+++ b/ios/Classes/FlutterWebviewPlugin.m
@@ -101,7 +101,7 @@ static NSString *const CHANNEL_NAME = @"flutter_webview_plugin";
     }
 
     CGRect rc;
-    if (rect != (id)[NSNull null]) {
+    if (rect != nil) {
         rc = [self parseRect:rect];
     } else {
         rc = self.viewController.view.bounds;


### PR DESCRIPTION
This is to address https://github.com/fluttercommunity/flutter_webview_plugin/issues/385 .

`rect != (id)[NSNull null]` was always evaluating to `true` when not providing a value for `rect` in the dart `launch` method:
`_webView.launch(url);`