### PR TITLE
Android: allow geolocation and file chooser simultaneously

### DIFF
--- a/android/src/main/java/com/flutter_webview_plugin/WebviewManager.java
+++ b/android/src/main/java/com/flutter_webview_plugin/WebviewManager.java
@@ -243,6 +243,10 @@ class WebviewManager {
                 args.put("progress", progress / 100.0);
                 FlutterWebviewPlugin.channel.invokeMethod("onProgressChanged", args);
             }
+
+            public void onGeolocationPermissionsShowPrompt(String origin, GeolocationPermissions.Callback callback) {
+                callback.invoke(origin, true, false);
+            }
         });
     }
 
@@ -367,12 +371,6 @@ class WebviewManager {
 
         if (geolocationEnabled) {
             webView.getSettings().setGeolocationEnabled(true);
-            webView.setWebChromeClient(new WebChromeClient() {
-                @Override
-                public void onGeolocationPermissionsShowPrompt(String origin, GeolocationPermissions.Callback callback) {
-                    callback.invoke(origin, true, false);
-                }
-            });
         }
 
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {


### PR DESCRIPTION
Merged file choosing (1) and geolocation (2) WebChromeClients into a single implementation to avoid 1 being overridden by 2