### PR TITLE
Add min sdk requirement and descriptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,9 @@ Plugin that allows Flutter to communicate with a native WebView.
 The webview is not integrated in the widget tree, it is a native view on top of the flutter view.
 You won't be able see snackbars, dialogs, or other flutter widgets that would overlap with the region of the screen taken up by the webview.
 
+The getSafeAcceptedType() function is available only for minimum SDK of 21.
+eval() function only supports SDK of 19 or greater for evaluating Javascript.
+
 ## Getting Started
 
 For help getting started with Flutter, view our online [documentation](http://flutter.io/).

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,12 +1,13 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
           xmlns:tools="http://schemas.android.com/tools"
           package="com.flutter_webview_plugin">
+    <uses-sdk android:minSdkVersion="16" />
     <application>
         <provider
             android:name="androidx.core.content.FileProvider"
             android:authorities="${applicationId}.fileprovider"
             android:exported="false"
-            android:grantUriPermissions="true" 
+            android:grantUriPermissions="true"
             tools:replace="android:authorities">
             <meta-data
                 android:name="android.support.FILE_PROVIDER_PATHS"


### PR DESCRIPTION
Currently flutter supports a minimum SDK version of 16 and all plugins should be able to match it, anything lower than that will probably cause some unwanted issues. We need to add those into Android Manifest and properly document it, same goes with the functions.