### PR TITLE
Fix iOS local URL support (fixes #114)

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ Future<String> loadJS(String name) async {
 ### Accessing local files in the file system
 Set the `withLocalUrl` option to true in the launch function or in the Webview scaffold to enable support for local URLs.
 
-Note that, on iOS, the `localUrlScope` option also needs to be set in the Webview scaffold to the local path where file access should be allowed, otherwise, only the requested file will be allowed, resulting in so subresources being loaded. This option is ignored on Android.
+Note that, on iOS, the `localUrlScope` option also needs to be set to a path to a directory. All files inside this folder (or subfolder) will be allowed access. If ommited, only the local file being opened will have access allowed, resulting in no subresources being loaded. This option is ignored on Android.
 
 ### Webview Events
 

--- a/README.md
+++ b/README.md
@@ -161,6 +161,10 @@ Future<String> loadJS(String name) async {
 }
 ```
 
+### Accessing local files in the file system
+Set the `withLocalUrl` option to true in the launch function or in the Webview scaffold to enable support for local URLs.
+
+Note that, on iOS, the `localUrlScope` option also needs to be set in the Webview scaffold to the local path where file access should be allowed, otherwise, only the requested file will be allowed, resulting in so subresources being loaded. This option is ignored on Android.
 
 ### Webview Events
 

--- a/README.md
+++ b/README.md
@@ -193,6 +193,7 @@ Future<Null> launch(String url, {
    bool withZoom: false,
    bool withLocalStorage: true,
    bool withLocalUrl: true,
+   String localUrlScope: null,
    bool scrollBar: true,
    bool supportMultipleWindows: false,
    bool appCacheEnabled: false,

--- a/ios/Classes/FlutterWebviewPlugin.m
+++ b/ios/Classes/FlutterWebviewPlugin.m
@@ -154,8 +154,15 @@ static NSString *const CHANNEL_NAME = @"flutter_webview_plugin";
             NSNumber *withLocalUrl = call.arguments[@"withLocalUrl"];
             if ( [withLocalUrl boolValue]) {
                 NSURL *htmlUrl = [NSURL fileURLWithPath:url isDirectory:false];
+                NSString *localUrlScope = call.arguments[@"localUrlScope"];
                 if (@available(iOS 9.0, *)) {
-                    [self.webview loadFileURL:htmlUrl allowingReadAccessToURL:htmlUrl];
+                    if(localUrlScope == nil) {
+                        [self.webview loadFileURL:htmlUrl allowingReadAccessToURL:htmlUrl];
+                    }
+                    else {
+                        NSURL *scopeUrl = [NSURL fileURLWithPath:localUrlScope];
+                        [self.webview loadFileURL:htmlUrl allowingReadAccessToURL:scopeUrl];
+                    }
                 } else {
                     @throw @"not available on version earlier than ios 9.0";
                 }
@@ -296,7 +303,8 @@ static NSString *const CHANNEL_NAME = @"flutter_webview_plugin";
     if (_enableAppScheme ||
         ([webView.URL.scheme isEqualToString:@"http"] ||
          [webView.URL.scheme isEqualToString:@"https"] ||
-         [webView.URL.scheme isEqualToString:@"about"])) {
+         [webView.URL.scheme isEqualToString:@"about"] ||
+         [webView.URL.scheme isEqualToString:@"file"])) {
          if (isInvalid) {
             decisionHandler(WKNavigationActionPolicyCancel);
          } else {

--- a/lib/src/base.dart
+++ b/lib/src/base.dart
@@ -106,6 +106,10 @@ class FlutterWebviewPlugin {
   ///     It is always enabled in UIWebView of iOS and  can not be disabled.
   /// - [withLocalUrl]: allow url as a local path
   ///     Allow local files on iOs > 9.0
+  /// - [localUrlScope]: allowed folder for local paths
+  ///     iOS only.
+  ///     If null and withLocalUrl is true, then it will use the url as the scope,
+  ///     allowing only itself to be read.
   /// - [scrollBar]: enable or disable scrollbar
   /// - [supportMultipleWindows] enable multiple windows support in Android
   /// - [invalidUrlRegex] is the regular expression of URLs that web view shouldn't load.
@@ -123,6 +127,7 @@ class FlutterWebviewPlugin {
     bool withZoom,
     bool withLocalStorage,
     bool withLocalUrl,
+    String localUrlScope,
     bool scrollBar,
     bool supportMultipleWindows,
     bool appCacheEnabled,
@@ -143,6 +148,7 @@ class FlutterWebviewPlugin {
       'withZoom': withZoom ?? false,
       'withLocalStorage': withLocalStorage ?? true,
       'withLocalUrl': withLocalUrl ?? false,
+      'localUrlScope': localUrlScope,
       'scrollBar': scrollBar ?? true,
       'supportMultipleWindows': supportMultipleWindows ?? false,
       'appCacheEnabled': appCacheEnabled ?? false,

--- a/lib/src/webview_scaffold.dart
+++ b/lib/src/webview_scaffold.dart
@@ -24,6 +24,7 @@ class WebviewScaffold extends StatefulWidget {
     this.withZoom,
     this.withLocalStorage,
     this.withLocalUrl,
+    this.localUrlScope,
     this.scrollBar,
     this.supportMultipleWindows,
     this.appCacheEnabled,
@@ -50,6 +51,7 @@ class WebviewScaffold extends StatefulWidget {
   final bool withZoom;
   final bool withLocalStorage;
   final bool withLocalUrl;
+  final String localUrlScope;
   final bool scrollBar;
   final bool supportMultipleWindows;
   final bool appCacheEnabled;
@@ -150,6 +152,7 @@ class _WebviewScaffoldState extends State<WebviewScaffold> {
               withZoom: widget.withZoom,
               withLocalStorage: widget.withLocalStorage,
               withLocalUrl: widget.withLocalUrl,
+              localUrlScope: widget.localUrlScope,
               scrollBar: widget.scrollBar,
               supportMultipleWindows: widget.supportMultipleWindows,
               appCacheEnabled: widget.appCacheEnabled,


### PR DESCRIPTION
Adds a new WebviewScaffold parameter called localUrlScope which is the allowed directory for the URL and sub-resources. This way, local HTML files can read local resources as well, within the allowed directory set in the new parameter. The file URI scheme is now also allowed. If localUrlScope is null, then the old behaviour is used, in which only the local file is allowed and sub-resources are disallowed.