### PR TITLE
bugfix: Added google() repository to allprojects to satisfy androidx build rules

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -27,6 +27,7 @@ buildscript {
 allprojects {
     repositories {
         jcenter()
+        google()
     }
 }
 


### PR DESCRIPTION
Adding the `flutter_webview_plugin` to a flutter submodule and using the [AAR approach](https://github.com/flutter/flutter/wiki/Add-Flutter-to-existing-apps) to add the module to an existing Android project brought up an issue that is detailed [here](https://github.com/flutter/flutter/issues/38416). The build process breaks at `:flutter:buildPluginReleaseFlutterWebviewPlugin` task.

Basically, the build.gradle lists out the transitive dependencies "implementation group: 'androidx.appcompat'" but does not mention `google()` under `allprojects/repositories`. And this dependency seems to be fulfilled from `google()` instead of `jcenter()`

After adding `google()`, the project builds perfectly. 