### PR TITLE
Make plugin work in headless mode when extending FlutterApplication

### DIFF
--- a/android/src/main/java/com/flutter_webview_plugin/FlutterWebviewPlugin.java
+++ b/android/src/main/java/com/flutter_webview_plugin/FlutterWebviewPlugin.java
@@ -32,10 +32,12 @@ public class FlutterWebviewPlugin implements MethodCallHandler, PluginRegistry.A
     private static final String JS_CHANNEL_NAMES_FIELD = "javascriptChannelNames";
 
     public static void registerWith(PluginRegistry.Registrar registrar) {
-        channel = new MethodChannel(registrar.messenger(), CHANNEL_NAME);
-        final FlutterWebviewPlugin instance = new FlutterWebviewPlugin(registrar.activity(), registrar.activeContext());
-        registrar.addActivityResultListener(instance);
-        channel.setMethodCallHandler(instance);
+        if (registrar.activity() != null) {
+            channel = new MethodChannel(registrar.messenger(), CHANNEL_NAME);
+            final FlutterWebviewPlugin instance = new FlutterWebviewPlugin(registrar.activity(), registrar.activeContext());
+            registrar.addActivityResultListener(instance);
+            channel.setMethodCallHandler(instance);
+        }
     }
 
     FlutterWebviewPlugin(Activity activity, Context context) {


### PR DESCRIPTION
When you extend `FlutterApplication` (e. g. to handle firebase messages in the background https://github.com/FirebaseExtended/flutterfire/tree/master/packages/firebase_messaging) then `registerWith` gets called with a registrar that has no activity.
When we check availablity of activity in the `registerWith` method then we can extend `FlutterApplication` without any problems.
Without this check callbacks like `onUrlChanged` and `onState` do not work.