### PR TITLE
Add ignore ssl error parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,32 @@ Set the `withLocalUrl` option to true in the launch function or in the Webview s
 
 Note that, on iOS, the `localUrlScope` option also needs to be set to a path to a directory. All files inside this folder (or subfolder) will be allowed access. If ommited, only the local file being opened will have access allowed, resulting in no subresources being loaded. This option is ignored on Android.
 
+### Ignoring SSL Errors
+
+Set the `ignoreSSLErrors` option to true to display content from servers with certificates usually not trusted by the Webview like self-signed certificates.
+
+**_Warning:_** Don't use this in production. 
+
+Note that on iOS you you need to add new key to `ios/Runner/Info.plist`
+
+```xml
+<key>NSAppTransportSecurity</key>
+<dict>
+    <key>NSAllowsArbitraryLoads</key>
+    <true/>
+    <key>NSAllowsArbitraryLoadsInWebContent</key>
+    <true/>
+</dict>
+```
+
+`NSAllowsArbitraryLoadsInWebContent` is for iOS 10+ and `NSAllowsArbitraryLoads` for iOS 9.
+Otherwise you'll still not be able to display content from pages with untrusted certificates.
+
+You can test your ignorance of ssl certificates is working e.g. through https://self-signed.badssl.com/ 
+
+
+
+
 ### Webview Events
 
 - `Stream<Null>` onDestroy
@@ -182,25 +208,30 @@ Note that, on iOS, the `localUrlScope` option also needs to be set to a path to 
 
 ```dart
 Future<Null> launch(String url, {
-   Map<String, String> headers: null,
-   bool withJavascript: true,
-   bool clearCache: false,
-   bool clearCookies: false,
-   bool hidden: false,
-   bool enableAppScheme: true,
-   Rect rect: null,
-   String userAgent: null,
-   bool withZoom: false,
-   bool withLocalStorage: true,
-   bool withLocalUrl: true,
-   String localUrlScope: null,
-   bool scrollBar: true,
-   bool supportMultipleWindows: false,
-   bool appCacheEnabled: false,
-   bool allowFileURLs: false,
-   bool displayZoomControls: false,
-   bool useWideViewPort: false,
-   bool withOverviewMode: false,
+    Map<String, String> headers: null,
+    Set<JavascriptChannel> javascriptChannels: null,
+    bool withJavascript: true,
+    bool clearCache: false,
+    bool clearCookies: false,
+    bool hidden: false,
+    bool enableAppScheme: true,
+    Rect rect: null,
+    String userAgent: null,
+    bool withZoom: false,
+    bool displayZoomControls: false,
+    bool withLocalStorage: true,
+    bool withLocalUrl: true,
+    String localUrlScope: null,
+    bool withOverviewMode: false,
+    bool scrollBar: true,
+    bool supportMultipleWindows: false,
+    bool appCacheEnabled: false,
+    bool allowFileURLs: false,
+    bool useWideViewPort: false,
+    String invalidUrlRegex: null,
+    bool geolocationEnabled: false,
+    bool debuggingEnabled: false,
+    bool ignoreSSLErrors: false,
 });
 ```
 

--- a/android/flutter_webview_plugin.iml
+++ b/android/flutter_webview_plugin.iml
@@ -4,6 +4,8 @@
     <facet type="android-gradle" name="Android-Gradle">
       <configuration>
         <option name="GRADLE_PROJECT_PATH" value=":flutter_webview_plugin" />
+        <option name="LAST_SUCCESSFUL_SYNC_AGP_VERSION" value="3.3.2" />
+        <option name="LAST_KNOWN_AGP_VERSION" value="3.3.2" />
       </configuration>
     </facet>
     <facet type="android" name="Android">
@@ -36,13 +38,6 @@
       <sourceFolder url="file://$MODULE_DIR$/src/debug/java" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/src/debug/rs" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/src/debug/shaders" isTestSource="false" />
-      <sourceFolder url="file://$MODULE_DIR$/src/testDebug/res" type="java-test-resource" />
-      <sourceFolder url="file://$MODULE_DIR$/src/testDebug/resources" type="java-test-resource" />
-      <sourceFolder url="file://$MODULE_DIR$/src/testDebug/assets" type="java-test-resource" />
-      <sourceFolder url="file://$MODULE_DIR$/src/testDebug/aidl" isTestSource="true" />
-      <sourceFolder url="file://$MODULE_DIR$/src/testDebug/java" isTestSource="true" />
-      <sourceFolder url="file://$MODULE_DIR$/src/testDebug/rs" isTestSource="true" />
-      <sourceFolder url="file://$MODULE_DIR$/src/testDebug/shaders" isTestSource="true" />
       <sourceFolder url="file://$MODULE_DIR$/src/androidTestDebug/res" type="java-test-resource" />
       <sourceFolder url="file://$MODULE_DIR$/src/androidTestDebug/resources" type="java-test-resource" />
       <sourceFolder url="file://$MODULE_DIR$/src/androidTestDebug/assets" type="java-test-resource" />
@@ -50,6 +45,13 @@
       <sourceFolder url="file://$MODULE_DIR$/src/androidTestDebug/java" isTestSource="true" />
       <sourceFolder url="file://$MODULE_DIR$/src/androidTestDebug/rs" isTestSource="true" />
       <sourceFolder url="file://$MODULE_DIR$/src/androidTestDebug/shaders" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/src/testDebug/res" type="java-test-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/src/testDebug/resources" type="java-test-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/src/testDebug/assets" type="java-test-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/src/testDebug/aidl" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/src/testDebug/java" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/src/testDebug/rs" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/src/testDebug/shaders" isTestSource="true" />
       <sourceFolder url="file://$MODULE_DIR$/src/main/res" type="java-resource" />
       <sourceFolder url="file://$MODULE_DIR$/src/main/resources" type="java-resource" />
       <sourceFolder url="file://$MODULE_DIR$/src/main/assets" type="java-resource" />
@@ -57,13 +59,6 @@
       <sourceFolder url="file://$MODULE_DIR$/src/main/java" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/src/main/rs" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/src/main/shaders" isTestSource="false" />
-      <sourceFolder url="file://$MODULE_DIR$/src/test/res" type="java-test-resource" />
-      <sourceFolder url="file://$MODULE_DIR$/src/test/resources" type="java-test-resource" />
-      <sourceFolder url="file://$MODULE_DIR$/src/test/assets" type="java-test-resource" />
-      <sourceFolder url="file://$MODULE_DIR$/src/test/aidl" isTestSource="true" />
-      <sourceFolder url="file://$MODULE_DIR$/src/test/java" isTestSource="true" />
-      <sourceFolder url="file://$MODULE_DIR$/src/test/rs" isTestSource="true" />
-      <sourceFolder url="file://$MODULE_DIR$/src/test/shaders" isTestSource="true" />
       <sourceFolder url="file://$MODULE_DIR$/src/androidTest/res" type="java-test-resource" />
       <sourceFolder url="file://$MODULE_DIR$/src/androidTest/resources" type="java-test-resource" />
       <sourceFolder url="file://$MODULE_DIR$/src/androidTest/assets" type="java-test-resource" />
@@ -71,99 +66,95 @@
       <sourceFolder url="file://$MODULE_DIR$/src/androidTest/java" isTestSource="true" />
       <sourceFolder url="file://$MODULE_DIR$/src/androidTest/rs" isTestSource="true" />
       <sourceFolder url="file://$MODULE_DIR$/src/androidTest/shaders" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/src/test/res" type="java-test-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/src/test/resources" type="java-test-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/src/test/assets" type="java-test-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/src/test/aidl" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/src/test/java" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/src/test/rs" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/src/test/shaders" isTestSource="true" />
     </content>
-    <content url="file://$MODULE_DIR$/../example/build/flutter_webview_plugin">
-      <sourceFolder url="file://$MODULE_DIR$/../example/build/flutter_webview_plugin/generated/source/apt/debug" isTestSource="false" generated="true" />
+    <content url="file://$MODULE_DIR$/../example/build/flutter_webview_plugin/generated/aidl_source_output_dir/debug/compileDebugAidl/out">
       <sourceFolder url="file://$MODULE_DIR$/../example/build/flutter_webview_plugin/generated/aidl_source_output_dir/debug/compileDebugAidl/out" isTestSource="false" generated="true" />
-      <sourceFolder url="file://$MODULE_DIR$/../example/build/flutter_webview_plugin/generated/source/buildConfig/debug" isTestSource="false" generated="true" />
-      <sourceFolder url="file://$MODULE_DIR$/../example/build/flutter_webview_plugin/generated/renderscript_source_output_dir/debug/compileDebugRenderscript/out" isTestSource="false" generated="true" />
-      <sourceFolder url="file://$MODULE_DIR$/../example/build/flutter_webview_plugin/generated/res/rs/debug" type="java-resource" />
-      <sourceFolder url="file://$MODULE_DIR$/../example/build/flutter_webview_plugin/generated/res/resValues/debug" type="java-resource" />
-      <sourceFolder url="file://$MODULE_DIR$/../example/build/flutter_webview_plugin/generated/source/apt/androidTest/debug" isTestSource="true" generated="true" />
+    </content>
+    <content url="file://$MODULE_DIR$/../example/build/flutter_webview_plugin/generated/aidl_source_output_dir/debugAndroidTest/compileDebugAndroidTestAidl/out">
       <sourceFolder url="file://$MODULE_DIR$/../example/build/flutter_webview_plugin/generated/aidl_source_output_dir/debugAndroidTest/compileDebugAndroidTestAidl/out" isTestSource="true" generated="true" />
-      <sourceFolder url="file://$MODULE_DIR$/../example/build/flutter_webview_plugin/generated/source/buildConfig/androidTest/debug" isTestSource="true" generated="true" />
+    </content>
+    <content url="file://$MODULE_DIR$/../example/build/flutter_webview_plugin/generated/renderscript_source_output_dir/debug/compileDebugRenderscript/out">
+      <sourceFolder url="file://$MODULE_DIR$/../example/build/flutter_webview_plugin/generated/renderscript_source_output_dir/debug/compileDebugRenderscript/out" isTestSource="false" generated="true" />
+    </content>
+    <content url="file://$MODULE_DIR$/../example/build/flutter_webview_plugin/generated/renderscript_source_output_dir/debugAndroidTest/compileDebugAndroidTestRenderscript/out">
       <sourceFolder url="file://$MODULE_DIR$/../example/build/flutter_webview_plugin/generated/renderscript_source_output_dir/debugAndroidTest/compileDebugAndroidTestRenderscript/out" isTestSource="true" generated="true" />
-      <sourceFolder url="file://$MODULE_DIR$/../example/build/flutter_webview_plugin/generated/res/rs/androidTest/debug" type="java-test-resource" />
-      <sourceFolder url="file://$MODULE_DIR$/../example/build/flutter_webview_plugin/generated/res/resValues/androidTest/debug" type="java-test-resource" />
+    </content>
+    <content url="file://$MODULE_DIR$/../example/build/flutter_webview_plugin/generated/res/resValues/androidTest/debug">
+      <sourceFolder url="file://$MODULE_DIR$/../example/build/flutter_webview_plugin/generated/res/resValues/androidTest/debug" type="java-test-resource" generated="true" />
+    </content>
+    <content url="file://$MODULE_DIR$/../example/build/flutter_webview_plugin/generated/res/resValues/debug">
+      <sourceFolder url="file://$MODULE_DIR$/../example/build/flutter_webview_plugin/generated/res/resValues/debug" type="java-resource" generated="true" />
+    </content>
+    <content url="file://$MODULE_DIR$/../example/build/flutter_webview_plugin/generated/res/rs/androidTest/debug">
+      <sourceFolder url="file://$MODULE_DIR$/../example/build/flutter_webview_plugin/generated/res/rs/androidTest/debug" type="java-test-resource" generated="true" />
+    </content>
+    <content url="file://$MODULE_DIR$/../example/build/flutter_webview_plugin/generated/res/rs/debug">
+      <sourceFolder url="file://$MODULE_DIR$/../example/build/flutter_webview_plugin/generated/res/rs/debug" type="java-resource" generated="true" />
+    </content>
+    <content url="file://$MODULE_DIR$/../example/build/flutter_webview_plugin/generated/source/apt/androidTest/debug">
+      <sourceFolder url="file://$MODULE_DIR$/../example/build/flutter_webview_plugin/generated/source/apt/androidTest/debug" isTestSource="true" generated="true" />
+    </content>
+    <content url="file://$MODULE_DIR$/../example/build/flutter_webview_plugin/generated/source/apt/debug">
+      <sourceFolder url="file://$MODULE_DIR$/../example/build/flutter_webview_plugin/generated/source/apt/debug" isTestSource="false" generated="true" />
+    </content>
+    <content url="file://$MODULE_DIR$/../example/build/flutter_webview_plugin/generated/source/apt/test/debug">
       <sourceFolder url="file://$MODULE_DIR$/../example/build/flutter_webview_plugin/generated/source/apt/test/debug" isTestSource="true" generated="true" />
-      <excludeFolder url="file://$MODULE_DIR$/../example/build/flutter_webview_plugin/generated/not_namespaced_r_class_sources" />
-      <excludeFolder url="file://$MODULE_DIR$/../example/build/flutter_webview_plugin/generated/source/r" />
-      <excludeFolder url="file://$MODULE_DIR$/../example/build/flutter_webview_plugin/intermediates/aapt_friendly_merged_manifests" />
-      <excludeFolder url="file://$MODULE_DIR$/../example/build/flutter_webview_plugin/intermediates/annotation_processor_list" />
-      <excludeFolder url="file://$MODULE_DIR$/../example/build/flutter_webview_plugin/intermediates/annotations_typedef_file" />
-      <excludeFolder url="file://$MODULE_DIR$/../example/build/flutter_webview_plugin/intermediates/annotations_zip" />
-      <excludeFolder url="file://$MODULE_DIR$/../example/build/flutter_webview_plugin/intermediates/blame" />
-      <excludeFolder url="file://$MODULE_DIR$/../example/build/flutter_webview_plugin/intermediates/check_manifest_result" />
-      <excludeFolder url="file://$MODULE_DIR$/../example/build/flutter_webview_plugin/intermediates/compile_only_not_namespaced_r_class_jar" />
-      <excludeFolder url="file://$MODULE_DIR$/../example/build/flutter_webview_plugin/intermediates/consumer_proguard_file" />
-      <excludeFolder url="file://$MODULE_DIR$/../example/build/flutter_webview_plugin/intermediates/incremental" />
-      <excludeFolder url="file://$MODULE_DIR$/../example/build/flutter_webview_plugin/intermediates/intermediate-jars" />
-      <excludeFolder url="file://$MODULE_DIR$/../example/build/flutter_webview_plugin/intermediates/javac" />
-      <excludeFolder url="file://$MODULE_DIR$/../example/build/flutter_webview_plugin/intermediates/jniLibs" />
-      <excludeFolder url="file://$MODULE_DIR$/../example/build/flutter_webview_plugin/intermediates/library_and_local_jars_jni" />
-      <excludeFolder url="file://$MODULE_DIR$/../example/build/flutter_webview_plugin/intermediates/library_assets" />
-      <excludeFolder url="file://$MODULE_DIR$/../example/build/flutter_webview_plugin/intermediates/library_manifest" />
-      <excludeFolder url="file://$MODULE_DIR$/../example/build/flutter_webview_plugin/intermediates/lint_jar" />
-      <excludeFolder url="file://$MODULE_DIR$/../example/build/flutter_webview_plugin/intermediates/merged_assets" />
-      <excludeFolder url="file://$MODULE_DIR$/../example/build/flutter_webview_plugin/intermediates/merged_manifests" />
-      <excludeFolder url="file://$MODULE_DIR$/../example/build/flutter_webview_plugin/intermediates/packaged-classes" />
-      <excludeFolder url="file://$MODULE_DIR$/../example/build/flutter_webview_plugin/intermediates/packaged_res" />
-      <excludeFolder url="file://$MODULE_DIR$/../example/build/flutter_webview_plugin/intermediates/public_res" />
-      <excludeFolder url="file://$MODULE_DIR$/../example/build/flutter_webview_plugin/intermediates/res" />
-      <excludeFolder url="file://$MODULE_DIR$/../example/build/flutter_webview_plugin/intermediates/rs" />
-      <excludeFolder url="file://$MODULE_DIR$/../example/build/flutter_webview_plugin/intermediates/shader_assets" />
-      <excludeFolder url="file://$MODULE_DIR$/../example/build/flutter_webview_plugin/intermediates/shaders" />
-      <excludeFolder url="file://$MODULE_DIR$/../example/build/flutter_webview_plugin/intermediates/sourceFolderJavaResources" />
-      <excludeFolder url="file://$MODULE_DIR$/../example/build/flutter_webview_plugin/intermediates/symbols" />
-      <excludeFolder url="file://$MODULE_DIR$/../example/build/flutter_webview_plugin/intermediates/tmp" />
-      <excludeFolder url="file://$MODULE_DIR$/../example/build/flutter_webview_plugin/intermediates/transforms" />
-      <excludeFolder url="file://$MODULE_DIR$/../example/build/flutter_webview_plugin/intermediates/unit_test_config_directory" />
-      <excludeFolder url="file://$MODULE_DIR$/../example/build/flutter_webview_plugin/outputs" />
-      <excludeFolder url="file://$MODULE_DIR$/../example/build/flutter_webview_plugin/reports" />
-      <excludeFolder url="file://$MODULE_DIR$/../example/build/flutter_webview_plugin/test-results" />
-      <excludeFolder url="file://$MODULE_DIR$/../example/build/flutter_webview_plugin/tmp" />
+    </content>
+    <content url="file://$MODULE_DIR$/../example/build/flutter_webview_plugin/generated/source/buildConfig/androidTest/debug">
+      <sourceFolder url="file://$MODULE_DIR$/../example/build/flutter_webview_plugin/generated/source/buildConfig/androidTest/debug" isTestSource="true" generated="true" />
+    </content>
+    <content url="file://$MODULE_DIR$/../example/build/flutter_webview_plugin/generated/source/buildConfig/debug">
+      <sourceFolder url="file://$MODULE_DIR$/../example/build/flutter_webview_plugin/generated/source/buildConfig/debug" isTestSource="false" generated="true" />
     </content>
     <orderEntry type="jdk" jdkName="Android API 28 Platform" jdkType="Android SDK" />
     <orderEntry type="sourceFolder" forTests="false" />
-    <orderEntry type="library" name="Gradle: androidx.swiperefreshlayout:swiperefreshlayout:1.0.0@aar" level="project" />
-    <orderEntry type="library" name="Gradle: androidx.legacy:legacy-support-core-ui:1.0.0@aar" level="project" />
-    <orderEntry type="library" name="Gradle: androidx.viewpager:viewpager:1.0.0@aar" level="project" />
-    <orderEntry type="library" name="Gradle: androidx.loader:loader:1.0.0@aar" level="project" />
-    <orderEntry type="library" scope="TEST" name="Gradle: org.objenesis:objenesis:2.6@jar" level="project" />
-    <orderEntry type="library" scope="TEST" name="Gradle: androidx.test:core:1.2.0@aar" level="project" />
-    <orderEntry type="library" name="Gradle: androidx.drawerlayout:drawerlayout:1.0.0@aar" level="project" />
-    <orderEntry type="library" name="Gradle: androidx.documentfile:documentfile:1.0.0@aar" level="project" />
-    <orderEntry type="library" name="Gradle: androidx.localbroadcastmanager:localbroadcastmanager:1.0.0@aar" level="project" />
-    <orderEntry type="library" name="Gradle: androidx.appcompat:appcompat:1.0.2@aar" level="project" />
-    <orderEntry type="library" name="Gradle: androidx.lifecycle:lifecycle-runtime:2.0.0@aar" level="project" />
-    <orderEntry type="library" name="Gradle: androidx.lifecycle:lifecycle-livedata-core:2.0.0@aar" level="project" />
-    <orderEntry type="library" name="Gradle: __local_aars__:/Users/rafal.wachol/Utils/flutter/bin/cache/artifacts/engine/android-arm/flutter.jar:unspecified@jar" level="project" />
-    <orderEntry type="library" name="Gradle: androidx.cursoradapter:cursoradapter:1.0.0@aar" level="project" />
-    <orderEntry type="library" name="Gradle: androidx.lifecycle:lifecycle-livedata:2.0.0@aar" level="project" />
-    <orderEntry type="library" name="Gradle: androidx.customview:customview:1.0.0@aar" level="project" />
-    <orderEntry type="library" name="Gradle: androidx.vectordrawable:vectordrawable-animated:1.0.0@aar" level="project" />
-    <orderEntry type="library" name="Gradle: androidx.asynclayoutinflater:asynclayoutinflater:1.0.0@aar" level="project" />
-    <orderEntry type="library" name="Gradle: androidx.vectordrawable:vectordrawable:1.0.1@aar" level="project" />
-    <orderEntry type="library" name="Gradle: androidx.interpolator:interpolator:1.0.0@aar" level="project" />
-    <orderEntry type="library" name="Gradle: androidx.fragment:fragment:1.0.0@aar" level="project" />
-    <orderEntry type="library" name="Gradle: androidx.lifecycle:lifecycle-common:2.0.0@jar" level="project" />
-    <orderEntry type="library" name="Gradle: androidx.legacy:legacy-support-core-utils:1.0.0@aar" level="project" />
-    <orderEntry type="library" name="Gradle: androidx.print:print:1.0.0@aar" level="project" />
-    <orderEntry type="library" name="Gradle: androidx.versionedparcelable:versionedparcelable:1.0.0@aar" level="project" />
-    <orderEntry type="library" name="Gradle: androidx.lifecycle:lifecycle-viewmodel:2.0.0@aar" level="project" />
-    <orderEntry type="library" name="Gradle: androidx.slidingpanelayout:slidingpanelayout:1.0.0@aar" level="project" />
-    <orderEntry type="library" name="Gradle: androidx.arch.core:core-common:2.0.0@jar" level="project" />
     <orderEntry type="library" scope="TEST" name="Gradle: junit:junit:4.12@jar" level="project" />
-    <orderEntry type="library" scope="TEST" name="Gradle: org.hamcrest:hamcrest-core:1.3@jar" level="project" />
-    <orderEntry type="library" name="Gradle: androidx.annotation:annotation:1.0.0@jar" level="project" />
-    <orderEntry type="library" name="Gradle: androidx.coordinatorlayout:coordinatorlayout:1.0.0@aar" level="project" />
-    <orderEntry type="library" scope="TEST" name="Gradle: androidx.test:monitor:1.2.0@aar" level="project" />
-    <orderEntry type="library" name="Gradle: androidx.arch.core:core-runtime:2.0.0@aar" level="project" />
-    <orderEntry type="library" name="Gradle: androidx.core:core:1.0.1@aar" level="project" />
     <orderEntry type="library" scope="TEST" name="Gradle: org.mockito:mockito-inline:2.28.2@jar" level="project" />
-    <orderEntry type="library" scope="TEST" name="Gradle: net.bytebuddy:byte-buddy-agent:1.9.10@jar" level="project" />
+    <orderEntry type="library" scope="TEST" name="Gradle: org.hamcrest:hamcrest-core:1.3@jar" level="project" />
     <orderEntry type="library" scope="TEST" name="Gradle: org.mockito:mockito-core:2.28.2@jar" level="project" />
     <orderEntry type="library" scope="TEST" name="Gradle: net.bytebuddy:byte-buddy:1.9.10@jar" level="project" />
+    <orderEntry type="library" scope="TEST" name="Gradle: net.bytebuddy:byte-buddy-agent:1.9.10@jar" level="project" />
+    <orderEntry type="library" scope="TEST" name="Gradle: org.objenesis:objenesis:2.6@jar" level="project" />
+    <orderEntry type="library" scope="TEST" name="Gradle: androidx.test:core:1.2.0@aar" level="project" />
+    <orderEntry type="library" scope="TEST" name="Gradle: androidx.test:monitor:1.2.0@aar" level="project" />
+    <orderEntry type="library" name="Gradle: __local_aars__:C.\flutter\bin\cache\artifacts\engine\android-arm64\flutter.jar:unspecified@jar" level="project" />
     <orderEntry type="library" name="Gradle: androidx.collection:collection:1.0.0@jar" level="project" />
+    <orderEntry type="library" name="Gradle: androidx.lifecycle:lifecycle-common:2.0.0@jar" level="project" />
+    <orderEntry type="library" name="Gradle: androidx.arch.core:core-common:2.0.0@jar" level="project" />
+    <orderEntry type="library" name="Gradle: androidx.annotation:annotation:1.0.0@jar" level="project" />
+    <orderEntry type="library" name="Gradle: androidx.appcompat:appcompat:1.0.2@aar" level="project" />
+    <orderEntry type="library" name="Gradle: androidx.fragment:fragment:1.0.0@aar" level="project" />
+    <orderEntry type="library" name="Gradle: androidx.vectordrawable:vectordrawable-animated:1.0.0@aar" level="project" />
+    <orderEntry type="library" name="Gradle: androidx.legacy:legacy-support-core-ui:1.0.0@aar" level="project" />
+    <orderEntry type="library" name="Gradle: androidx.legacy:legacy-support-core-utils:1.0.0@aar" level="project" />
+    <orderEntry type="library" name="Gradle: androidx.vectordrawable:vectordrawable:1.0.1@aar" level="project" />
+    <orderEntry type="library" name="Gradle: androidx.loader:loader:1.0.0@aar" level="project" />
+    <orderEntry type="library" name="Gradle: androidx.viewpager:viewpager:1.0.0@aar" level="project" />
+    <orderEntry type="library" name="Gradle: androidx.coordinatorlayout:coordinatorlayout:1.0.0@aar" level="project" />
+    <orderEntry type="library" name="Gradle: androidx.drawerlayout:drawerlayout:1.0.0@aar" level="project" />
+    <orderEntry type="library" name="Gradle: androidx.slidingpanelayout:slidingpanelayout:1.0.0@aar" level="project" />
+    <orderEntry type="library" name="Gradle: androidx.customview:customview:1.0.0@aar" level="project" />
+    <orderEntry type="library" name="Gradle: androidx.swiperefreshlayout:swiperefreshlayout:1.0.0@aar" level="project" />
+    <orderEntry type="library" name="Gradle: androidx.asynclayoutinflater:asynclayoutinflater:1.0.0@aar" level="project" />
+    <orderEntry type="library" name="Gradle: androidx.core:core:1.0.1@aar" level="project" />
+    <orderEntry type="library" name="Gradle: androidx.versionedparcelable:versionedparcelable:1.0.0@aar" level="project" />
+    <orderEntry type="library" name="Gradle: androidx.cursoradapter:cursoradapter:1.0.0@aar" level="project" />
+    <orderEntry type="library" name="Gradle: androidx.lifecycle:lifecycle-runtime:2.0.0@aar" level="project" />
+    <orderEntry type="library" name="Gradle: androidx.documentfile:documentfile:1.0.0@aar" level="project" />
+    <orderEntry type="library" name="Gradle: androidx.localbroadcastmanager:localbroadcastmanager:1.0.0@aar" level="project" />
+    <orderEntry type="library" name="Gradle: androidx.print:print:1.0.0@aar" level="project" />
+    <orderEntry type="library" name="Gradle: androidx.lifecycle:lifecycle-viewmodel:2.0.0@aar" level="project" />
+    <orderEntry type="library" name="Gradle: androidx.lifecycle:lifecycle-livedata:2.0.0@aar" level="project" />
+    <orderEntry type="library" name="Gradle: androidx.lifecycle:lifecycle-livedata-core:2.0.0@aar" level="project" />
+    <orderEntry type="library" name="Gradle: androidx.arch.core:core-runtime:2.0.0@aar" level="project" />
+    <orderEntry type="library" name="Gradle: androidx.interpolator:interpolator:1.0.0@aar" level="project" />
+    <orderEntry type="library" name="Gradle: android-android-28" level="project" />
   </component>
 </module>

--- a/android/src/main/java/com/flutter_webview_plugin/FlutterWebviewPlugin.java
+++ b/android/src/main/java/com/flutter_webview_plugin/FlutterWebviewPlugin.java
@@ -108,6 +108,7 @@ public class FlutterWebviewPlugin implements MethodCallHandler, PluginRegistry.A
         String invalidUrlRegex = call.argument("invalidUrlRegex");
         boolean geolocationEnabled = call.argument("geolocationEnabled");
         boolean debuggingEnabled = call.argument("debuggingEnabled");
+        boolean ignoreSSLErrors = call.argument("ignoreSSLErrors");
 
         if (webViewManager == null || webViewManager.closed == true) {
             Map<String, Object> arguments = (Map<String, Object>) call.arguments;
@@ -140,7 +141,8 @@ public class FlutterWebviewPlugin implements MethodCallHandler, PluginRegistry.A
                 useWideViewPort,
                 invalidUrlRegex,
                 geolocationEnabled,
-                debuggingEnabled
+                debuggingEnabled,
+                ignoreSSLErrors
         );
         result.success(null);
     }

--- a/example/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
+++ b/example/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
@@ -27,8 +27,6 @@
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES">
-      <Testables>
-      </Testables>
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
@@ -38,8 +36,8 @@
             ReferencedContainer = "container:Runner.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
-      <AdditionalOptions>
-      </AdditionalOptions>
+      <Testables>
+      </Testables>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"
@@ -61,8 +59,6 @@
             ReferencedContainer = "container:Runner.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"

--- a/example/ios/Runner/Info.plist
+++ b/example/ios/Runner/Info.plist
@@ -41,5 +41,10 @@
 	</array>
 	<key>UIViewControllerBasedStatusBarAppearance</key>
 	<false/>
+	<key>NSAppTransportSecurity</key>
+	<dict>
+		<key>NSAllowsArbitraryLoadsInWebContent</key>
+		<true/>
+	</dict>
 </dict>
 </plist>

--- a/ios/Classes/FlutterWebviewPlugin.m
+++ b/ios/Classes/FlutterWebviewPlugin.m
@@ -159,7 +159,6 @@ static NSString *const CHANNEL_NAME = @"flutter_webview_plugin";
 
 - (void)webView:(WKWebView *)webView didReceiveAuthenticationChallenge:(NSURLAuthenticationChallenge *)challenge completionHandler:(void (^)(NSURLSessionAuthChallengeDisposition disposition, NSURLCredential *credential))completionHandler {
     if ([_ignoreSSLErrors boolValue]){
-        NSLog(@"Allow invalid certificates");
         SecTrustRef serverTrust = challenge.protectionSpace.serverTrust;
         CFDataRef exceptions = SecTrustCopyExceptions(serverTrust);
         SecTrustSetExceptions(serverTrust, exceptions);
@@ -168,7 +167,6 @@ static NSString *const CHANNEL_NAME = @"flutter_webview_plugin";
                           [NSURLCredential credentialForTrust:serverTrust]);
     }
     else {
-        NSLog(@"Block invalid certificates");
         completionHandler(NSURLSessionAuthChallengePerformDefaultHandling,nil);
     }
     

--- a/lib/src/base.dart
+++ b/lib/src/base.dart
@@ -140,6 +140,7 @@ class FlutterWebviewPlugin {
   /// - [displayZoomControls]: display zoom controls on webview
   /// - [withOverviewMode]: enable overview mode for Android webview ( setLoadWithOverviewMode )
   /// - [useWideViewPort]: use wide viewport for Android webview ( setUseWideViewPort )
+  /// - [ignoreSSLErrors]: use to bypass Android/iOS SSL checks e.g. for self-signed certificates
   Future<Null> launch(
     String url, {
     Map<String, String> headers,
@@ -165,6 +166,7 @@ class FlutterWebviewPlugin {
     String invalidUrlRegex,
     bool geolocationEnabled,
     bool debuggingEnabled,
+    bool ignoreSSLErrors,
   }) async {
     final args = <String, dynamic>{
       'url': url,
@@ -188,6 +190,7 @@ class FlutterWebviewPlugin {
       'geolocationEnabled': geolocationEnabled ?? false,
       'withOverviewMode': withOverviewMode ?? false,
       'debuggingEnabled': debuggingEnabled ?? false,
+      'ignoreSSLErrors': ignoreSSLErrors ?? true,
     };
 
     if (headers != null) {

--- a/lib/src/base.dart
+++ b/lib/src/base.dart
@@ -190,7 +190,7 @@ class FlutterWebviewPlugin {
       'geolocationEnabled': geolocationEnabled ?? false,
       'withOverviewMode': withOverviewMode ?? false,
       'debuggingEnabled': debuggingEnabled ?? false,
-      'ignoreSSLErrors': ignoreSSLErrors ?? true,
+      'ignoreSSLErrors': ignoreSSLErrors ?? false,
     };
 
     if (headers != null) {

--- a/lib/src/webview_scaffold.dart
+++ b/lib/src/webview_scaffold.dart
@@ -39,6 +39,7 @@ class WebviewScaffold extends StatefulWidget {
     this.invalidUrlRegex,
     this.geolocationEnabled,
     this.debuggingEnabled = false,
+    this.ignoreSSLErrors = false,
   }) : super(key: key);
 
   final PreferredSizeWidget appBar;
@@ -70,6 +71,7 @@ class WebviewScaffold extends StatefulWidget {
   final bool withOverviewMode;
   final bool useWideViewPort;
   final bool debuggingEnabled;
+  final bool ignoreSSLErrors;
 
   @override
   _WebviewScaffoldState createState() => _WebviewScaffoldState();
@@ -174,6 +176,7 @@ class _WebviewScaffoldState extends State<WebviewScaffold> {
               invalidUrlRegex: widget.invalidUrlRegex,
               geolocationEnabled: widget.geolocationEnabled,
               debuggingEnabled: widget.debuggingEnabled,
+              ignoreSSLErrors: widget.ignoreSSLErrors,
             );
           } else {
             if (_rect != value) {


### PR DESCRIPTION
This relates  to https://github.com/fluttercommunity/flutter_webview_plugin/issues/298 where in certain situations users have to ignore SSL certificates, e.g when working in test environments with self-signed certificates.  
The new optional flag _ignoreSSLErrors_ which defaults to false allows just that. 
