### PR TITLE
bumped up version to 0.3.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# 0.3.9
+
+- Fixed error methods on iOS
+- fixed build
+- fixed ios clean cookies
+- 4 Make plugin work in headless mode when extending FlutterApplication
+- added canGoBack and canGoForward methods
+
 # 0.3.8
 
 - Fix iOS local URL support (fixes #114)

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -7,7 +7,7 @@ authors:
 - Simon Lightfoot <simon@devangels.london>
 - Rafal Wachol <gorudonu@gmail.com>
 homepage: https://github.com/dart-flitter/flutter_webview_plugin
-version: 0.3.8
+version: 0.3.9
 maintainer: Rafal Wachol (@RafalWachol) 
 
 environment:


### PR DESCRIPTION
new version release

- Fixed error methods on iOS
- fixed build
- fixed ios clean cookies
- 4 Make plugin work in headless mode when extending FlutterApplication
- added canGoBack and canGoForward methods