### PR TITLE
add a new method to get cookies

### DIFF
--- a/android/src/main/java/com/flutter_webview_plugin/FlutterWebviewPlugin.java
+++ b/android/src/main/java/com/flutter_webview_plugin/FlutterWebviewPlugin.java
@@ -6,6 +6,7 @@ import android.content.Context;
 import android.content.Intent;
 import android.graphics.Point;
 import android.view.Display;
+import android.webkit.CookieManager;
 import android.webkit.WebStorage;
 import android.widget.FrameLayout;
 import android.webkit.CookieManager;
@@ -91,6 +92,9 @@ public class FlutterWebviewPlugin implements MethodCallHandler, PluginRegistry.A
             case "canGoForward":
                 canGoForward(result);
                 break;
+            case "getAllCookies":
+                getAllCookies(call, result);
+                break;
             case "cleanCache":
                 cleanCache(result);
                 break;
@@ -98,6 +102,13 @@ public class FlutterWebviewPlugin implements MethodCallHandler, PluginRegistry.A
                 result.notImplemented();
                 break;
         }
+    }
+
+    private void getAllCookies(MethodCall call, MethodChannel.Result result) {
+        String url = call.argument("url");
+        CookieManager cookieManager = CookieManager.getInstance();
+        String cookieStr = cookieManager.getCookie(url);
+        result.success(cookieStr);
     }
 
     private void cleanCache(MethodChannel.Result result) {

--- a/ios/Classes/FlutterWebviewPlugin.m
+++ b/ios/Classes/FlutterWebviewPlugin.m
@@ -72,6 +72,10 @@ static NSString *const CHANNEL_NAME = @"flutter_webview_plugin";
     } else if ([@"reload" isEqualToString:call.method]) {
         [self reload];
         result(nil);
+    } else if ([@"getAllCookies" isEqualToString:call.method]){
+        [self getAllCookies:call completionHandler:^(NSString *cookies) {
+            result(cookies);
+        }];
     } else if ([@"canGoBack" isEqualToString:call.method]) {
         [self onCanGoBack:call result:result];
     } else if ([@"canGoForward" isEqualToString:call.method]) {
@@ -204,6 +208,26 @@ static NSString *const CHANNEL_NAME = @"flutter_webview_plugin";
                 [self.webview loadRequest:request];
             }
         }
+}
+
+- (void)getAllCookies:(FlutterMethodCall*)call
+     completionHandler:(void (^_Nullable)(NSString * cookies))completionHandler {
+    if (self.webview != nil) {
+        NSString *url = call.arguments[@"url"];
+        WKHTTPCookieStore *cookieStore = self.webview.configuration.websiteDataStore.httpCookieStore;
+        [cookieStore getAllCookies:^(NSArray<NSHTTPCookie *> * _Nonnull cookies) {
+            NSString *allCookies = @"";
+            NSEnumerator *cookie_enum = [cookies objectEnumerator];
+            NSHTTPCookie *temp_cookie;
+            while (temp_cookie = [cookie_enum nextObject]) {
+                NSString *temp = [NSString stringWithFormat:@"%@=%@;",[temp_cookie name],[temp_cookie value]];
+                allCookies = [allCookies stringByAppendingString:temp];
+            }
+            completionHandler([NSString stringWithFormat:@"%@", allCookies]);
+        }];
+    } else {
+        completionHandler(nil);
+    }
 }
 
 - (void)evalJavascript:(FlutterMethodCall*)call

--- a/lib/src/base.dart
+++ b/lib/src/base.dart
@@ -290,6 +290,13 @@ class FlutterWebviewPlugin {
     _instance = null;
   }
 
+  // get all cookies including "http only"
+  // but for ios, it only support ios 11 or above
+  Future<String> getAllCookies(String url) async {
+    final res = await _channel.invokeMethod('getAllCookies', {'url': url});
+    return res;
+  }
+
   Future<Map<String, String>> getCookies() async {
     final cookiesString = await evalJavascript('document.cookie');
     final cookies = <String, String>{};


### PR DESCRIPTION
Old method “getCookies" can not get cookie which is "http only".
So add a new method to resolve this issue.
But for IOS, it only support ios 11 or above
