### PR TITLE
Use custom file provider

### DIFF
--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -4,7 +4,7 @@
 
     <application>
         <provider
-            android:name="androidx.core.content.FileProvider"
+            android:name="com.flutter_webview_plugin.FlutterWebviewPluginFileProvider"
             android:authorities="${applicationId}.fileprovider"
             android:exported="false"
             android:grantUriPermissions="true"

--- a/android/src/main/java/com/flutter_webview_plugin/FlutterWebviewPluginFileProvider.java
+++ b/android/src/main/java/com/flutter_webview_plugin/FlutterWebviewPluginFileProvider.java
@@ -1,0 +1,7 @@
+package com.flutter_webview_plugin;
+
+import androidx.core.content.FileProvider;
+
+public class FlutterWebviewPluginFileProvider extends FileProvider {
+
+}

--- a/android/src/main/java/com/flutter_webview_plugin/WebviewManager.java
+++ b/android/src/main/java/com/flutter_webview_plugin/WebviewManager.java
@@ -21,8 +21,6 @@ import android.webkit.WebView;
 import android.widget.FrameLayout;
 import android.provider.MediaStore;
 
-import androidx.core.content.FileProvider;
-
 import android.database.Cursor;
 import android.provider.OpenableColumns;
 
@@ -287,7 +285,7 @@ class WebviewManager {
         } catch (IOException e) {
             e.printStackTrace();
         }
-        return FileProvider.getUriForFile(context, packageName + ".fileprovider", capturedFile);
+        return FlutterWebviewPluginFileProvider.getUriForFile(context, packageName + ".fileprovider", capturedFile);
     }
 
     private File createCapturedFile(String prefix, String suffix) throws IOException {


### PR DESCRIPTION
Avoids collision with other plugins, such as `open_file`.

Same fixes:
* https://github.com/sidlatau/flutter_email_sender/commit/c3ec68fc2e68a152bd20221e84fc75332597b538
* https://github.com/sangcomz/FishBun/pull/151/files

Related issues:
* https://github.com/fluttercommunity/flutter_webview_plugin/issues/411
* https://github.com/fluttercommunity/flutter_webview_plugin/issues/621