### PR TITLE
Add an option to enable third party cookies in the webView

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,7 +196,8 @@ Otherwise you'll still not be able to display content from pages with untrusted 
 
 You can test your ignorance if ssl certificates is working e.g. through https://self-signed.badssl.com/ 
 
-
+### Enabling third party cookies
+Set the `thirdPartyCookiesEnabled` option to true in the launch function or in the Webview scaffold to enable third party cookies in the WebView. This option is ignored on iOS.
 
 
 ### Webview Events
@@ -239,6 +240,7 @@ Future<Null> launch(String url, {
     bool geolocationEnabled: false,
     bool debuggingEnabled: false,
     bool ignoreSSLErrors: false,
+    bool thirdPartyCookiesEnabled: false,
 });
 ```
 

--- a/android/src/main/java/com/flutter_webview_plugin/FlutterWebviewPlugin.java
+++ b/android/src/main/java/com/flutter_webview_plugin/FlutterWebviewPlugin.java
@@ -128,6 +128,7 @@ public class FlutterWebviewPlugin implements MethodCallHandler, PluginRegistry.A
         boolean geolocationEnabled = call.argument("geolocationEnabled");
         boolean debuggingEnabled = call.argument("debuggingEnabled");
         boolean ignoreSSLErrors = call.argument("ignoreSSLErrors");
+        boolean thirdPartyCookiesEnabled = call.argument("thirdPartyCookiesEnabled");
 
         if (webViewManager == null || webViewManager.closed == true) {
             Map<String, Object> arguments = (Map<String, Object>) call.arguments;
@@ -162,7 +163,8 @@ public class FlutterWebviewPlugin implements MethodCallHandler, PluginRegistry.A
                 invalidUrlRegex,
                 geolocationEnabled,
                 debuggingEnabled,
-                ignoreSSLErrors
+                ignoreSSLErrors,
+                thirdPartyCookiesEnabled
         );
         result.success(null);
     }

--- a/android/src/main/java/com/flutter_webview_plugin/WebviewManager.java
+++ b/android/src/main/java/com/flutter_webview_plugin/WebviewManager.java
@@ -380,7 +380,8 @@ class WebviewManager {
             String invalidUrlRegex,
             boolean geolocationEnabled,
             boolean debuggingEnabled,
-            boolean ignoreSSLErrors
+            boolean ignoreSSLErrors,
+            boolean thirdPartyCookiesEnabled
     ) {
         webView.getSettings().setJavaScriptEnabled(withJavascript);
         webView.getSettings().setBuiltInZoomControls(withZoom);
@@ -444,6 +445,10 @@ class WebviewManager {
             webView.loadUrl(url, headers);
         } else {
             webView.loadUrl(url);
+        }
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+          CookieManager.getInstance().setAcceptThirdPartyCookies(webView, thirdPartyCookiesEnabled);
         }
     }
 

--- a/lib/src/base.dart
+++ b/lib/src/base.dart
@@ -141,6 +141,7 @@ class FlutterWebviewPlugin {
   /// - [withOverviewMode]: enable overview mode for Android webview ( setLoadWithOverviewMode )
   /// - [useWideViewPort]: use wide viewport for Android webview ( setUseWideViewPort )
   /// - [ignoreSSLErrors]: use to bypass Android/iOS SSL checks e.g. for self-signed certificates
+  /// - [thirdPartyCookiesEnabled]: use to enable third party cookies in the WebView
   Future<Null> launch(
     String url, {
     Map<String, String> headers,
@@ -168,6 +169,7 @@ class FlutterWebviewPlugin {
     bool geolocationEnabled,
     bool debuggingEnabled,
     bool ignoreSSLErrors,
+    bool thirdPartyCookiesEnabled,
   }) async {
     final args = <String, dynamic>{
       'url': url,
@@ -193,6 +195,7 @@ class FlutterWebviewPlugin {
       'withOverviewMode': withOverviewMode ?? false,
       'debuggingEnabled': debuggingEnabled ?? false,
       'ignoreSSLErrors': ignoreSSLErrors ?? false,
+      'thirdPartyCookiesEnabled': thirdPartyCookiesEnabled ?? false,
     };
 
     if (headers != null) {

--- a/lib/src/webview_scaffold.dart
+++ b/lib/src/webview_scaffold.dart
@@ -41,6 +41,7 @@ class WebviewScaffold extends StatefulWidget {
     this.geolocationEnabled,
     this.debuggingEnabled = false,
     this.ignoreSSLErrors = false,
+    this.thirdPartyCookiesEnabled = false,
   }) : super(key: key);
 
   final PreferredSizeWidget appBar;
@@ -74,6 +75,7 @@ class WebviewScaffold extends StatefulWidget {
   final bool useWideViewPort;
   final bool debuggingEnabled;
   final bool ignoreSSLErrors;
+  final bool thirdPartyCookiesEnabled;
 
   @override
   _WebviewScaffoldState createState() => _WebviewScaffoldState();
@@ -180,6 +182,7 @@ class _WebviewScaffoldState extends State<WebviewScaffold> {
               geolocationEnabled: widget.geolocationEnabled,
               debuggingEnabled: widget.debuggingEnabled,
               ignoreSSLErrors: widget.ignoreSSLErrors,
+              thirdPartyCookiesEnabled: widget.thirdPartyCookiesEnabled,
             );
           } else {
             if (_rect != value) {


### PR DESCRIPTION
I added an option called `thirdPartyCookiesEnabled` to enable third party cookies in the WebView. 

The default value is false.

This option is only for android because WKWebview does not support setCookieAcceptPolicy.