### PR TITLE
Add an option to set cache mode on Android webview

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,7 +196,9 @@ Otherwise you'll still not be able to display content from pages with untrusted 
 
 You can test your ignorance if ssl certificates is working e.g. through https://self-signed.badssl.com/ 
 
+### Set cache mode
 
+Set the `cacheMode` option to override the way the cache is used on Android Webview. It could be `LOAD_CACHE_ONLY`, `LOAD_CACHE_ELSE_NETWORK`, `LOAD_NO_CACHE` or `LOAD_DEFAULT`. The default value is affected by another option `appCacheEnabled`. If `appCacheEnabled` is  true, `cacheMode` is decided by what user set. If `appCacheEnabled` is false, `cacheMode` becomes `LOAD_NO_CACHE`.
 
 
 ### Webview Events
@@ -239,6 +241,7 @@ Future<Null> launch(String url, {
     bool geolocationEnabled: false,
     bool debuggingEnabled: false,
     bool ignoreSSLErrors: false,
+    String cacheMode: null,
 });
 ```
 

--- a/android/src/main/java/com/flutter_webview_plugin/FlutterWebviewPlugin.java
+++ b/android/src/main/java/com/flutter_webview_plugin/FlutterWebviewPlugin.java
@@ -128,6 +128,7 @@ public class FlutterWebviewPlugin implements MethodCallHandler, PluginRegistry.A
         boolean geolocationEnabled = call.argument("geolocationEnabled");
         boolean debuggingEnabled = call.argument("debuggingEnabled");
         boolean ignoreSSLErrors = call.argument("ignoreSSLErrors");
+        String cacheMode = call.argument("cacheMode");
 
         if (webViewManager == null || webViewManager.closed == true) {
             Map<String, Object> arguments = (Map<String, Object>) call.arguments;
@@ -162,7 +163,8 @@ public class FlutterWebviewPlugin implements MethodCallHandler, PluginRegistry.A
                 invalidUrlRegex,
                 geolocationEnabled,
                 debuggingEnabled,
-                ignoreSSLErrors
+                ignoreSSLErrors,
+                cacheMode
         );
         result.success(null);
     }

--- a/android/src/main/java/com/flutter_webview_plugin/WebviewManager.java
+++ b/android/src/main/java/com/flutter_webview_plugin/WebviewManager.java
@@ -352,6 +352,26 @@ class WebviewManager {
         webView.clearFormData();
     }
 
+    private void setCacheMode(Boolean appCacheEnabled, String cacheModeString) {
+      Integer cacheMode;
+      if (appCacheEnabled) {
+        switch (cacheModeString) {
+          case "LOAD_CACHE_ONLY":
+            cacheMode = WebSettings.LOAD_CACHE_ONLY;
+            break;
+          case "LOAD_CACHE_ELSE_NETWORK":
+            cacheMode = WebSettings.LOAD_CACHE_ELSE_NETWORK;
+            break;
+          default:
+            cacheMode = WebSettings.LOAD_DEFAULT;
+            break;
+        }
+      } else {
+        cacheMode = WebSettings.LOAD_NO_CACHE;
+      }
+      webView.getSettings().setCacheMode(cacheMode);
+    }
+
     private void registerJavaScriptChannelNames(List<String> channelNames) {
         for (String channelName : channelNames) {
             webView.addJavascriptInterface(
@@ -380,7 +400,8 @@ class WebviewManager {
             String invalidUrlRegex,
             boolean geolocationEnabled,
             boolean debuggingEnabled,
-            boolean ignoreSSLErrors
+            boolean ignoreSSLErrors,
+            String cacheMode
     ) {
         webView.getSettings().setJavaScriptEnabled(withJavascript);
         webView.getSettings().setBuiltInZoomControls(withZoom);
@@ -444,6 +465,10 @@ class WebviewManager {
             webView.loadUrl(url, headers);
         } else {
             webView.loadUrl(url);
+        }
+
+        if (cacheMode != null) {
+          setCacheMode(appCacheEnabled, cacheMode);
         }
     }
 

--- a/lib/src/base.dart
+++ b/lib/src/base.dart
@@ -141,6 +141,7 @@ class FlutterWebviewPlugin {
   /// - [withOverviewMode]: enable overview mode for Android webview ( setLoadWithOverviewMode )
   /// - [useWideViewPort]: use wide viewport for Android webview ( setUseWideViewPort )
   /// - [ignoreSSLErrors]: use to bypass Android/iOS SSL checks e.g. for self-signed certificates
+  /// - [cacheMode]: use to set cache mode for Android webview
   Future<Null> launch(
     String url, {
     Map<String, String> headers,
@@ -168,6 +169,7 @@ class FlutterWebviewPlugin {
     bool geolocationEnabled,
     bool debuggingEnabled,
     bool ignoreSSLErrors,
+    String cacheMode,
   }) async {
     final args = <String, dynamic>{
       'url': url,
@@ -193,6 +195,7 @@ class FlutterWebviewPlugin {
       'withOverviewMode': withOverviewMode ?? false,
       'debuggingEnabled': debuggingEnabled ?? false,
       'ignoreSSLErrors': ignoreSSLErrors ?? false,
+      'cacheMode': cacheMode,
     };
 
     if (headers != null) {

--- a/lib/src/webview_scaffold.dart
+++ b/lib/src/webview_scaffold.dart
@@ -41,6 +41,7 @@ class WebviewScaffold extends StatefulWidget {
     this.geolocationEnabled,
     this.debuggingEnabled = false,
     this.ignoreSSLErrors = false,
+    this.cacheMode,
   }) : super(key: key);
 
   final PreferredSizeWidget appBar;
@@ -74,6 +75,7 @@ class WebviewScaffold extends StatefulWidget {
   final bool useWideViewPort;
   final bool debuggingEnabled;
   final bool ignoreSSLErrors;
+  final String cacheMode;
 
   @override
   _WebviewScaffoldState createState() => _WebviewScaffoldState();
@@ -180,6 +182,7 @@ class _WebviewScaffoldState extends State<WebviewScaffold> {
               geolocationEnabled: widget.geolocationEnabled,
               debuggingEnabled: widget.debuggingEnabled,
               ignoreSSLErrors: widget.ignoreSSLErrors,
+              cacheMode: widget.cacheMode,
             );
           } else {
             if (_rect != value) {


### PR DESCRIPTION
I added an option `cacheMode` to override the way the cache is used on Android Webview.

It could be `LOAD_CACHE_ONLY`, `LOAD_CACHE_ELSE_NETWORK`, `LOAD_NO_CACHE` or `LOAD_DEFAULT`.

The default value is affected by another option `appCacheEnabled`. If `appCacheEnabled` is  true, `cacheMode` is decided by what user set. If `appCacheEnabled` is false, `cacheMode` becomes `LOAD_NO_CACHE`.