### PR TITLE
Fix CookieGetter's bug

### DIFF
--- a/lib/src/base.dart
+++ b/lib/src/base.dart
@@ -302,7 +302,7 @@ class FlutterWebviewPlugin {
     if (cookiesString?.isNotEmpty == true) {
       cookiesString.split(';').forEach((String cookie) {
         final split = cookie.split('=');
-        cookies[split[0]] = split[1];
+        cookies[split[0].trim()] = split[1];
       });
     }
 


### PR DESCRIPTION
There are extre spaces in the key of the website's cookie.so I think just need to add ".trim()"