### PR TITLE
Allow clients to fetch all cookies including HttpOnly.

### DIFF
--- a/android/src/main/java/com/flutter_webview_plugin/FlutterWebviewPlugin.java
+++ b/android/src/main/java/com/flutter_webview_plugin/FlutterWebviewPlugin.java
@@ -94,9 +94,18 @@ public class FlutterWebviewPlugin implements MethodCallHandler, PluginRegistry.A
             case "cleanCache":
                 cleanCache(result);
                 break;
+            case "getAllCookies":
+                getAllCookies(call, result);
+                break;
             default:
                 result.notImplemented();
                 break;
+        }
+    }
+
+    private void getAllCookies(MethodCall call, final MethodChannel.Result result){
+        if (webViewManager != null){
+            webViewManager.getAllCookies(call,result);
         }
     }
 

--- a/android/src/main/java/com/flutter_webview_plugin/WebviewManager.java
+++ b/android/src/main/java/com/flutter_webview_plugin/WebviewManager.java
@@ -347,6 +347,13 @@ class WebviewManager {
         }
     }
 
+    void getAllCookies(MethodCall call, final MethodChannel.Result result){
+        String url = call.argument("url");
+        CookieManager cookieManager = CookieManager.getInstance();
+        String cookieStr = cookieManager.getCookie(url);
+        result.success(cookieStr);
+    }
+
     private void clearCache() {
         webView.clearCache(true);
         webView.clearFormData();

--- a/ios/Classes/FlutterWebviewPlugin.m
+++ b/ios/Classes/FlutterWebviewPlugin.m
@@ -79,6 +79,10 @@ static NSString *const CHANNEL_NAME = @"flutter_webview_plugin";
         [self onCanGoForward:call result:result];
     } else if ([@"cleanCache" isEqualToString:call.method]) {
         [self cleanCache:result];
+    } else if ([@"getAllCookies" isEqualToString:call.method]) {
+        [self getAllCookies:call completionHandler:^(NSString *cookies) {
+            result(cookies);
+        }];
     } else {
         result(FlutterMethodNotImplemented);
     }
@@ -300,6 +304,26 @@ static NSString *const CHANNEL_NAME = @"flutter_webview_plugin";
           // support for iOS8 tracked in https://github.com/flutter/flutter/issues/27624.
           NSLog(@"Clearing cookies is not supported for Flutter WebViews prior to iOS 9.");
         }
+    }
+}
+
+- (void)getAllCookies:(FlutterMethodCall*)call
+     completionHandler:(void (^_Nullable)(NSString * cookies))completionHandler {
+    if (self.webview != nil) {
+        NSString *url = call.arguments[@"url"];
+        WKHTTPCookieStore *cookieStore = self.webview.configuration.websiteDataStore.httpCookieStore;
+        [cookieStore getAllCookies:^(NSArray<NSHTTPCookie *> * _Nonnull cookies) {
+            NSString *allCookies = @"";
+            NSEnumerator *cookie_enum = [cookies objectEnumerator];
+            NSHTTPCookie *temp_cookie;
+            while (temp_cookie = [cookie_enum nextObject]) {
+                NSString *temp = [NSString stringWithFormat:@"%@=%@;",[temp_cookie name],[temp_cookie value]];
+                allCookies = [allCookies stringByAppendingString:temp];
+            }
+            completionHandler([NSString stringWithFormat:@"%@", allCookies]);
+        }];
+    } else {
+        completionHandler(nil);
     }
 }
 

--- a/lib/src/base.dart
+++ b/lib/src/base.dart
@@ -295,6 +295,22 @@ class FlutterWebviewPlugin {
     _instance = null;
   }
 
+  // get all cookies including HttpOnly
+  // but for ios, it only support ios 11 or above
+  Future<Map<String, String>> getAllCookies(String url) async {
+    final cookiesString = await _channel.invokeMethod('getAllCookies', {'url': url});
+    final cookies = <String, String>{};
+
+    if (cookiesString?.isNotEmpty == true) {
+      cookiesString.split(';').forEach((String cookie) {
+        final split = cookie.split('=');
+        cookies[split[0].trim()] = split[1].trim();
+      });
+    }
+
+    return cookies;
+  }
+
   Future<Map<String, String>> getCookies() async {
     final cookiesString = await evalJavascript('document.cookie');
     final cookies = <String, String>{};


### PR DESCRIPTION
Current implementation of `getCookies` uses javascript `document.cookie` to get cookies. However , it doesn't return HttpOnly cookies which can be set server side. The reason for this is javascript doesn't have access to HttpOnly cookies. This PR contains addition method called `getAllCookies` that return all cookies that has beed set.