### PR TITLE
Allow underscore middle of name in JavascriptChannel

### DIFF
--- a/lib/src/javascript_channel.dart
+++ b/lib/src/javascript_channel.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/foundation.dart';
 import 'package:flutter_webview_plugin/flutter_webview_plugin.dart';
 
-final RegExp _validChannelNames = RegExp('^[a-zA-Z_][a-zA-Z0-9]*\$');
+final RegExp _validChannelNames = RegExp('^[a-zA-Z_][a-zA-Z0-9_]*\$');
 
 /// A named channel for receiving messaged from JavaScript code running inside a web view.
 class JavascriptChannel {


### PR DESCRIPTION
## Use case
When I try to use JavascriptChannel like this. 
JavascriptChannel throws error. 

```
JavascriptChannel(
  name: 'foo_action',
  onMessageReceived: (JavascriptMessage message) {
    // do something ...
  }
)
```
It said name is not valid. 
And the reason was underscore in the name of JavascriptCannel.
As matter of fact, there is not any reference that JavacriptInterface does not allow underscore for javascript function name. 

## Proposal

I think it can be fixed with this change in javascript_channel.dart.

### Before
https://github.com/fluttercommunity/flutter_webview_plugin/blob/4862bd987cf8ce6695d8d280ab407d57e5ae30f0/lib/src/javascript_channel.dart#L3-L5

### After
```
final RegExp _validChannelNames = RegExp('^[a-zA-Z_][a-zA-Z0-9_]*\$');
```
