### PR TITLE
File upload crash of FileProvider name collisions

### DIFF
--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,11 +1,14 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-          xmlns:tools="http://schemas.android.com/tools"
-          package="com.flutter_webview_plugin">
+    xmlns:tools="http://schemas.android.com/tools"
+    package="com.flutter_webview_plugin">
+
+    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
+    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
 
     <application>
         <provider
-            android:name="androidx.core.content.FileProvider"
-            android:authorities="${applicationId}.fileprovider"
+            android:name=".FlutterWebviewFileProvider"
+            android:authorities="${applicationId}.flutter_webview_fileprovider"
             android:exported="false"
             android:grantUriPermissions="true"
             tools:replace="android:authorities">

--- a/android/src/main/java/com/flutter_webview_plugin/FlutterWebviewFileProvider.java
+++ b/android/src/main/java/com/flutter_webview_plugin/FlutterWebviewFileProvider.java
@@ -1,0 +1,13 @@
+package com.flutter_webview_plugin;
+
+import androidx.core.content.FileProvider;
+
+/**
+ * Created by Konoha on 15/08/2020
+ *
+ * Providing a custom {@code FileProvider} prevents manifest {@code <provider>} name collisions.
+ *
+ * <p>See https://developer.android.com/guide/topics/manifest/provider-element.html for details.
+ */
+public class FlutterWebviewFileProvider extends FileProvider {
+}

--- a/android/src/main/java/com/flutter_webview_plugin/WebviewManager.java
+++ b/android/src/main/java/com/flutter_webview_plugin/WebviewManager.java
@@ -287,7 +287,7 @@ class WebviewManager {
         } catch (IOException e) {
             e.printStackTrace();
         }
-        return FileProvider.getUriForFile(context, packageName + ".fileprovider", capturedFile);
+        return FileProvider.getUriForFile(context, packageName + ".flutter_webview_fileprovider", capturedFile);
     }
 
     private File createCapturedFile(String prefix, String suffix) throws IOException {


### PR DESCRIPTION
Providing a custom {@code FileProvider} prevents manifest {@code <provider>} name collisions.
Define <uses-permission> for  READ_EXTERNAL_STORAGE and WRITE_EXTERNAL_STORAGE
It will reslove the problem about upload Picture on webpage