### PR TITLE
onReceivedError

### DIFF
--- a/android/src/main/java/com/flutter_webview_plugin/BrowserClient.java
+++ b/android/src/main/java/com/flutter_webview_plugin/BrowserClient.java
@@ -99,6 +99,14 @@ public class BrowserClient extends WebViewClient {
         FlutterWebviewPlugin.channel.invokeMethod("onHttpError", data);
     }
 
+    @TargetApi(android.os.Build.VERSION_CODES.M)
+    @Override
+    public void onReceivedError(WebView view, WebResourceRequest req, WebResourceError rerr) {
+        // Redirect to deprecated method, so you can use it in all SDK versions
+        onReceivedError(view, rerr.getErrorCode(), rerr.getDescription().toString(), req.getUrl().toString());
+    }
+
+    @SuppressWarnings("deprecation")
     @Override
     public void onReceivedError(WebView view, int errorCode, String description, String failingUrl) {
         super.onReceivedError(view, errorCode, description, failingUrl);


### PR DESCRIPTION
Detail for
warning: [deprecation] (shouldOverrideUrlLoading,onReceivedError,removeAllCookie) in WebViewClient has been deprecated #734