### PR TITLE
add SuppressWarnings

### DIFF
--- a/android/src/main/java/com/flutter_webview_plugin/BrowserClient.java
+++ b/android/src/main/java/com/flutter_webview_plugin/BrowserClient.java
@@ -76,6 +76,7 @@ public class BrowserClient extends WebViewClient {
         return isInvalid;
     }
 
+    @SuppressWarnings("deprecation")
     @Override
     public boolean shouldOverrideUrlLoading(WebView view, String url) {
         // returning true causes the current WebView to abort loading the URL,


### PR DESCRIPTION
you already use `boolean shouldOverrideUrlLoading(WebView view, WebResourceRequest request)` new method.
so, I just added `SuppressWarnings`

Detail for warning: [deprecation] (shouldOverrideUrlLoading,onReceivedError,removeAllCookie) in WebViewClient has been deprecated #734